### PR TITLE
Remove unnecessary totalLabelsMap to prevent memory leak.

### DIFF
--- a/modules/gui/src/com/haulmont/timesheets/gui/approve/ApproveScreen.java
+++ b/modules/gui/src/com/haulmont/timesheets/gui/approve/ApproveScreen.java
@@ -115,8 +115,6 @@ public class ApproveScreen extends AbstractWindow {
     @Inject
     private LookupField task;
 
-    protected Map<String, Label> totalLabelsMap = new HashMap<>();
-
     protected Date firstDayOfWeek;
     protected Date lastDayOfWeek;
     protected List<Project> managedProjects;
@@ -175,14 +173,6 @@ public class ApproveScreen extends AbstractWindow {
         initDaysColumns();
         initTotalColumn();
         initActionsColumn();
-
-        weeklyEntriesDs.addCollectionChangeListener(e -> {
-            if (Operation.REMOVE.equals(e.getOperation()) || Operation.CLEAR.equals(e.getOperation())) {
-                for (WeeklyReportEntry entry : e.getItems()) {
-                    totalLabelsMap.remove(ComponentsHelper.getCacheKeyForEntity(entry, TOTAL_COLUMN_ID));
-                }
-            }
-        });
 
         weeklyReportsTable.setStyleProvider((entity, property) -> {
             String id = null;
@@ -308,7 +298,6 @@ public class ApproveScreen extends AbstractWindow {
         weeklyReportsTable.addGeneratedColumn(TOTAL_COLUMN_ID, entity -> {
             Label label = componentsFactory.createComponent(Label.class);
             label.setValue(entity.getTotal());
-            totalLabelsMap.put(ComponentsHelper.getCacheKeyForEntity(entity, TOTAL_COLUMN_ID), label);
             return label;
         });
         weeklyReportsTable.setColumnWidth(TOTAL_COLUMN_ID, 80);


### PR DESCRIPTION
The usage of this map is only put some labels into it and remove some labels from, but never get result.
But, in cases with bulk approving (last days of month, for example) this map grows to 800Mb per session, which is bad.